### PR TITLE
Lint workflow uses Node 16.x; format job has been properly defined

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: node setup
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
           
       - name: lint
         run: |


### PR DESCRIPTION
Lint workflow now uses Node 16.x. I accidentally set this to 14.x before

Format job of feature workflow now properly checks out the repository before trying to work on it. Previously, it was a lint and format combination which I didn't split up properly.