### PR TITLE
Developer focus/repo spread

### DIFF
--- a/src/database/statistics/developerFocus.service.ts
+++ b/src/database/statistics/developerFocus.service.ts
@@ -13,10 +13,9 @@ import {
 import { RepositoryDocument } from '../schemas/repository.schema';
 import { getSpreadsForDev } from './dateUtil';
 import {
-  rearangeTimeslots,
-  getRepoSpreadTotal,
+  getAvgSpreadPerTimeInterval,
   getAvgRepoSpread,
-  getSpreadDates,
+  getSpreadDataPerTimeIntervals,
 } from './spreadUtil';
 
 @Injectable()
@@ -176,7 +175,6 @@ export class DeveloperFocus {
   }
 
   /**
-   *
    * Adds the given @param repoId to the timestamp map.
    * If map doesn't contain the @param timestamps the entry is added.
    */
@@ -321,11 +319,12 @@ export class DeveloperFocus {
   }
 
   /**
-   * This method calculates the developer Spread for a specified repository only.
-   * Therefor, it calls getRepoCommits() to get all developers of the repo in the first place.
-   * Then, it calls devSpread() to get all spreads for each developer of that orga, the repo is corresponding to.
-   * Then, only those devs are taken into account, whose contributed to the desired repo in a specific timeslot.
-   * @param repoIdent The repo identification including repo id and orga
+   * Calculates the developer spread in certain repository @param repoIdent.
+   * Spread data comes from precomputed DevSpread data.
+   * It calculates the avg spread at a time category per developer.
+   * Then, it @returns the avg spread per time category.
+   * @param loginFilter developer logins which should be considered.
+   * @param userLimit limits the amount of commits.
    */
   async devSpreadRepo(
     repoIdent: RepositoryNameDto,
@@ -342,56 +341,30 @@ export class DeveloperFocus {
       .findOne({ repo: repoIdent.repo, owner: repoIdent.owner })
       .exec();
 
-    // get the commits for specified repo to get the developers of that repo
-    const commits = await this.getRepoCommits(
-      repoM._id,
+    const repoID = repoM._id.toString();
+
+    // get the precomputed spreads for every organisation developer
+    const spreadsPerDevs = await this.devSpread(
+      repoIdent.owner,
       loginFilter,
       userLimit,
     );
-    this.logger.log('commits: ', commits);
-    // store the repoId as a string
-    const repoID = repoM._id.toString();
-    // store the repo developers in an array
-    const repoDevs = Object.keys(commits);
-    // get the precomputed spreads for every organisation developer
-    const spreadsPerDevs = await this.devSpread(repoIdent.owner);
 
-    // store all corresponding commits for every time category,
-    // in which a developer contributed to the specified repo,
-    // with the timestamp and the developer spread in that specific
-    // timeslot directly.
-    // TODO: refactor utility method
-    const dates: RepoSpread = getSpreadDates(repoID, repoDevs, spreadsPerDevs);
+    const spreads: RepoSpread = getSpreadDataPerTimeIntervals(
+      repoID,
+      spreadsPerDevs,
+    );
+    this.logger.log(spreads);
 
-    this.logger.log(dates);
+    // sum of spread values for devs at a timestamp / amount of devs who contributed
+    const repoSpread: RepoSpreadTotal = getAvgSpreadPerTimeInterval(spreads);
 
-    // Now, we need a little fix; consider dev A, which has contributed in week X,
-    // which starts at '2021-09-06' and then in week Y which starts at '2021-09-13' again,
-    // because his timeslots were calculated with his daily commit timestamps like this.
-    // Now, dev B has his own time interval computation based on his daily commit timestamps,
-    // consider he has contributed in wee week Z which starts at '2021-09-09'.
-    // So, we don't want to count the weeks as 3 weeks, as the week Z actually belongs in week X,
-    // we want to have 2 weeks of them and add dev B to the week X and delete week Z.
-    // This happens in rearangeTimeSlots() for weeks, sprints and months, as days
-    // are already precisely.
-    dates.weekSpread = rearangeTimeslots(dates.weekSpread, 7);
-    dates.sprintSpread = rearangeTimeslots(dates.sprintSpread, 14);
-    dates.monthSpread = rearangeTimeslots(dates.monthSpread, 30);
-
-    this.logger.log(dates);
-
-    // this is the presicely repository spread with timestamp:spread pairs for each category
-    // the spread is beeing calculated with the sum of the dev spreads which contributed in that timestamp
-    // devided trough the amount of devs
-    const repoSpread: RepoSpreadTotal = getRepoSpreadTotal(dates);
-
-    // TODO: this could also be returned as a good overview n the whole repo histroy, if desired.
     this.logger.log(repoSpread);
 
-    // finally, build the average daySpread, weekSpread, ..., of all single daySpreads, weekSpreads, ...
+    // sum of avg spread values in a time category / amount of time category items
     const avgRepoSpread: RepoSpreadAvg = getAvgRepoSpread(repoSpread);
-    this.logger.log(avgRepoSpread);
 
+    this.logger.log(avgRepoSpread);
     return avgRepoSpread;
   }
 }

--- a/src/database/statistics/developerFocus.service.ts
+++ b/src/database/statistics/developerFocus.service.ts
@@ -8,12 +8,12 @@ import {
   DevSpreadTotal,
   RepoSpread,
   RepoSpreadAvg,
-  RepoSpreadTotal,
+  RepoSpreadPerInterval,
 } from 'src/github-api/model/DevFocus';
 import { RepositoryDocument } from '../schemas/repository.schema';
 import { getSpreadsForDev } from './dateUtil';
 import {
-  getAvgSpreadPerTimeInterval,
+  getSpreadSizePerTimeInterval,
   getAvgRepoSpread,
   getSpreadDataPerTimeIntervals,
 } from './spreadUtil';
@@ -357,7 +357,8 @@ export class DeveloperFocus {
     this.logger.log(spreads);
 
     // sum of spread values for devs at a timestamp / amount of devs who contributed
-    const repoSpread: RepoSpreadTotal = getAvgSpreadPerTimeInterval(spreads);
+    const repoSpread: RepoSpreadPerInterval =
+      getSpreadSizePerTimeInterval(spreads);
 
     this.logger.log(repoSpread);
 

--- a/src/github-api/github-api.service.ts
+++ b/src/github-api/github-api.service.ts
@@ -83,10 +83,10 @@ export class GithubApiService {
     // ]);
     //this.statisticService.faultCorrectionEfficiency(repoIdent);
     // this.statisticService.workInProgress(repoIdent);
-    this.devFocus.devSpreadTotal(
-      repoIdent.owner,
-      //   await this.orgaMembers(repoIdent.owner),
-    );
+    // this.devFocus.devSpreadTotal(
+    //   repoIdent.owner,
+    //   await this.orgaMembers(repoIdent.owner),
+    // );
     this.devFocus.devSpreadRepo(
       repoIdent,
       // await this.orgaMembers(repoIdent.owner),

--- a/src/github-api/github-api.service.ts
+++ b/src/github-api/github-api.service.ts
@@ -70,9 +70,9 @@ export class GithubApiService {
 
     // this.statisticService.avgTimeTillTicketWasAssigned(repoIdent);
     //this.statisticService.workInProgress(repoIdent);
-    return await this.featureCompletion.featureCompletionCapability(repoIdent, [
-      'feature',
-    ]);
+    // return await this.featureCompletion.featureCompletionCapability(repoIdent, [
+    //   'feature',
+    // ]);
 
     // return await this.faultCorrection.faultCorrectionRate(repoIdent, [
     //   'support',
@@ -83,14 +83,14 @@ export class GithubApiService {
     // ]);
     //this.statisticService.faultCorrectionEfficiency(repoIdent);
     // this.statisticService.workInProgress(repoIdent);
-    // this.devFocus.devSpreadTotal(
-    //  repoIdent.owner,
-    //   await this.orgaMembers(repoIdent.owner),
-    //);
-    // this.devFocus.devSpreadRepo(
-    //   repoIdent,
-    // await this.orgaMembers(repoIdent.owner),
-    // );
+    this.devFocus.devSpreadTotal(
+      repoIdent.owner,
+      //   await this.orgaMembers(repoIdent.owner),
+    );
+    this.devFocus.devSpreadRepo(
+      repoIdent,
+      // await this.orgaMembers(repoIdent.owner),
+    );
   }
 
   public async orgaMembers(owner: string) {

--- a/src/github-api/model/DevFocus.ts
+++ b/src/github-api/model/DevFocus.ts
@@ -42,14 +42,17 @@ export interface DevSpreadTotal {
 }
 
 export interface RepoSpread {
-  daySpread: { [key: string]: { [key: string]: number } };
-  weekSpread: { [key: string]: { [key: string]: number } };
-  sprintSpread: { [key: string]: { [key: string]: number } };
-  monthSpread: { [key: string]: { [key: string]: number } };
-  days: number;
-  weeks: number;
-  sprints: number;
-  months: number;
+  daySpread: { [key: string]: Set<string> };
+  weekSpread: { [key: string]: Set<string> };
+  sprintSpread: { [key: string]: Set<string> };
+  monthSpread: { [key: string]: Set<string> };
+}
+
+export interface RepoSpreadPerInterval {
+  daySpread: { [key: string]: number };
+  weekSpread: { [key: string]: number };
+  sprintSpread: { [key: string]: number };
+  monthSpread: { [key: string]: number };
 }
 
 export interface RepoSpreadAvg {
@@ -57,11 +60,4 @@ export interface RepoSpreadAvg {
   weekSpread: number;
   sprintSpread: number;
   monthSpread: number;
-}
-
-export interface RepoSpreadTotal {
-  daySpread: { [key: string]: number };
-  weekSpread: { [key: string]: number };
-  sprintSpread: { [key: string]: number };
-  monthSpread: { [key: string]: number };
 }


### PR DESCRIPTION
Update of the repository spread calculation. 

@DieserFelix please check, if we need a weighted average again, as we calculate an average of averages, too. I am not quite sure about it.

Consider the following day spread data:
```
'2021-09-17': { gr2m: 9, 'web-flow': 3 },
'2021-09-22': { gr2m: 2, 'web-flow': 2 },
'2021-08-03': { gr2m: 2 },
'2021-08-09': { gr2m: 2 },
'2021-08-10': { gr2m: 1 },
```

This would lead to this average spread at those days

```
'2021-09-17': 6,
'2021-09-22': 2,
'2021-08-03': 2,
'2021-08-09': 2,
'2021-08-10': 1,
```

If we would weight the average now, we calculate `6*2/7 + 2*2/7 ...  = 3` and if we would not weight the average, we get `(6 + 3*2 + 1)/5 = 2.2`.

At the moment, I am doing the last one.
So our expression here is now an average spread per time items in a category instead of an average spread per dev (weighted) as in the total repo spread.