### PR TITLE
Developer focus / sprints

### DIFF
--- a/src/database/statistics/dateUtil.ts
+++ b/src/database/statistics/dateUtil.ts
@@ -1,4 +1,4 @@
-import { DevSpreadDates } from 'src/github-api/model/DevFocus';
+import { DevSpreadDates, SprintData } from 'src/github-api/model/DevFocus';
 
 /**
  * Computes all spread values for a developer,
@@ -10,9 +10,13 @@ import { DevSpreadDates } from 'src/github-api/model/DevFocus';
  * the sum of the spread for each time category
  * and the total number of timestamps in a category (days, weeks, ...)
  */
-export function getSpreadsForDev(timeRepoPairs: {
-  [key: string]: string[];
-}): DevSpreadDates {
+export function getSpreadsForDev(
+  timeRepoPairs: {
+    [key: string]: string[];
+  },
+  dev: string,
+  sprintData?: SprintData[],
+): DevSpreadDates {
   // sort because timestamp order is broken after mixing them together from different repos
   const timestamps: string[] = Object.keys(timeRepoPairs).sort();
 
@@ -20,7 +24,9 @@ export function getSpreadsForDev(timeRepoPairs: {
     timeRepoPairs,
     timestamps,
   );
-  dates = calculateSprintsByWeeks(dates);
+  if (sprintData != undefined) {
+    dates = calculateSprintsBySprintData(dates, dev, sprintData);
+  }
   return dates;
 }
 
@@ -218,34 +224,52 @@ function yearsAreEqual(year1: number, year2: number): boolean {
 
 /**
  * Calculates sprintSpread, sprintSpreadSum and sprints for
- * @param dates, based on the precalculated weeks in weekSpread.
- * Therefor, if a week and its successor week are a sprint,
- * the week spreads of the single weeks are being merged
- * and the start week number builds the new entry in sprintSpread object.
+ * @param dates, based on the precalculated commits in daySpread.
+ * The sprint time slots and participants are provided by @param sprintData
+ * and it compares to the current @param dev.
  * @returns DevSpreadDates for a developer,
  * with all sprint related values being calculated.
  */
-function calculateSprintsByWeeks(dates: DevSpreadDates): DevSpreadDates {
-  const weekSpread = dates.weekSpread;
-  const weeks = Object.keys(weekSpread);
+function calculateSprintsBySprintData(
+  dates: DevSpreadDates,
+  dev: string,
+  sprintData: SprintData[],
+): DevSpreadDates {
+  // TODO: sort sprintData Objects by begin timestamp. I would do this with lodash sortBy then.
   let sprintSpreadSum = 0;
-  for (let i = 0; i < weeks.length; ) {
-    let currentWeek = Number(weeks[i]);
-    let nextWeek = Number(weeks[i + 1]);
-    if (datesAreSprint(currentWeek, nextWeek)) {
-      const currentRepos = weekSpread[currentWeek];
-      const nextRepos = weekSpread[nextWeek];
-      const mergedRepos = [].concat(currentRepos, nextRepos);
-      dates.sprintSpread[currentWeek] = Array.from(new Set(mergedRepos));
-      sprintSpreadSum += dates.sprintSpread[currentWeek].length;
-      i += 2;
-    } else {
-      i += 1;
+  for (const sprint of sprintData) {
+    if (sprint.developers.includes(dev)) {
+      const duration: string = sprint.begin + '-' + sprint.end;
+      dates.sprintSpread[duration] = [];
+      for (const commit in dates.daySpread) {
+        const repoArr = dates.daySpread[commit];
+        const sprintArr = dates.sprintSpread[duration];
+        if (isCommitinSprint(commit, sprint.begin, sprint.end)) {
+          const mergedRepos = [].concat(repoArr, sprintArr);
+          dates.sprintSpread[duration] = Array.from(new Set(mergedRepos));
+        }
+      }
+      sprintSpreadSum += dates.sprintSpread[duration].length;
+      // just keep sprints, if there is at least one contribution during the sprint
+      if (dates.sprintSpread[duration].length == 0) {
+        delete dates.sprintSpread[duration];
+      }
     }
   }
   dates.sprintSpreadSum = sprintSpreadSum;
   dates.sprints = Object.keys(dates.sprintSpread).length;
+  dates.sprintSpread = dates.sprintSpread;
   return dates;
+}
+
+/**
+ * @returns true, if @param commit date is between the interval starting
+ * from @param begin date and ending at @param end date.
+ */
+function isCommitinSprint(commit: string, begin: string, end: string) {
+  return (
+    new Date(begin) <= new Date(commit) && new Date(commit) <= new Date(end)
+  );
 }
 
 /**

--- a/src/database/statistics/developerFocus.service.ts
+++ b/src/database/statistics/developerFocus.service.ts
@@ -9,6 +9,7 @@ import {
   RepoSpread,
   RepoSpreadAvg,
   RepoSpreadTotal,
+  SprintData,
 } from 'src/github-api/model/DevFocus';
 import { RepositoryDocument } from '../schemas/repository.schema';
 import { getSpreadsForDev } from './dateUtil';
@@ -112,6 +113,7 @@ export class DeveloperFocus {
     owner: string,
     loginFilter?: string[],
     userLimit?: number,
+    sprintData?: SprintData[],
   ): Promise<DevSpread> {
     const repoIds: { _id: string }[] = await this.repoModel
       .aggregate()
@@ -153,7 +155,7 @@ export class DeveloperFocus {
 
     devToTimestampToRepo.forEach((timeToRepo, dev) => {
       const timeToRepoObj = Object.fromEntries(timeToRepo);
-      spreadsPerDevs[dev] = getSpreadsForDev(timeToRepoObj);
+      spreadsPerDevs[dev] = getSpreadsForDev(timeToRepoObj, dev, sprintData);
     });
 
     this.logger.log(spreadsPerDevs);
@@ -226,11 +228,13 @@ export class DeveloperFocus {
     owner: string,
     loginFilter?: string[],
     userLimit?: number,
+    sprintData?: SprintData[],
   ): Promise<DevSpreadTotal> {
     const spreadsPerDevs: DevSpread = await this.devSpread(
       owner,
       loginFilter,
       userLimit,
+      sprintData,
     );
 
     const allDevelopers: string[] = Object.keys(spreadsPerDevs);
@@ -297,11 +301,8 @@ export class DeveloperFocus {
 
       totalSpread.daySpread += devObj.daySpread * getWeight(dev, 'days');
       totalSpread.weekSpread += devObj.weekSpread * getWeight(dev, 'weeks');
-      // if dev has no sprints, exlude him from the calculation
-      if (!(devObj.sprints == 0)) {
-        totalSpread.sprintSpread +=
-          devObj.sprintSpread * getWeight(dev, 'sprints');
-      }
+      totalSpread.sprintSpread +=
+        devObj.sprintSpread * getWeight(dev, 'sprints');
       totalSpread.monthSpread += devObj.monthSpread * getWeight(dev, 'months');
     }
 

--- a/src/github-api/github-api.service.ts
+++ b/src/github-api/github-api.service.ts
@@ -5,6 +5,7 @@ import { StatisticService } from 'src/database/statistic.service';
 import { DeveloperFocus } from 'src/database/statistics/developerFocus.service';
 import { FaultCorrection } from 'src/database/statistics/faultCorrection.service';
 import { FeatureCompletion } from 'src/database/statistics/featureCompletion.service';
+import { SprintData } from './model/DevFocus';
 import { PullRequest, RepositoryFile, Commit } from './model/PullRequest';
 import { CreateRepositoryDto, RepositoryNameDto } from './model/Repository';
 
@@ -58,6 +59,12 @@ export class GithubApiService {
   }
 
   public async getStatistics(repoIdent: RepositoryNameDto) {
+    const testSprints: SprintData[] = [
+      { begin: '08.02.21', end: '08.15.21', developers: ['gr2m', 'web-flow'] },
+      { begin: '08.16.21', end: '08.29.21', developers: ['gr2m', 'web-flow'] },
+      { begin: '07.05.21', end: '07.11.21', developers: ['gr2m'] },
+      { begin: '09.20.21', end: '10.10.21', developers: ['web-flow'] },
+    ];
     // this.statisticService.getMostChangedFiles(repoIdent);
     // this.statisticService.getFilesChangedTogether(repoIdent);
     // this.statisticService.sizeOfPullRequest(repoIdent);
@@ -70,9 +77,9 @@ export class GithubApiService {
 
     // this.statisticService.avgTimeTillTicketWasAssigned(repoIdent);
     //this.statisticService.workInProgress(repoIdent);
-    return await this.featureCompletion.featureCompletionCapability(repoIdent, [
-      'feature',
-    ]);
+    // return await this.featureCompletion.featureCompletionCapability(repoIdent, [
+    //   'feature',
+    // ]);
 
     // return await this.faultCorrection.faultCorrectionRate(repoIdent, [
     //   'support',
@@ -83,10 +90,13 @@ export class GithubApiService {
     // ]);
     //this.statisticService.faultCorrectionEfficiency(repoIdent);
     // this.statisticService.workInProgress(repoIdent);
-    // this.devFocus.devSpreadTotal(
-    //  repoIdent.owner,
-    //   await this.orgaMembers(repoIdent.owner),
-    //);
+    this.devFocus.devSpreadTotal(
+      repoIdent.owner,
+      undefined,
+      undefined,
+      testSprints,
+      //   await this.orgaMembers(repoIdent.owner),
+    );
     // this.devFocus.devSpreadRepo(
     //   repoIdent,
     // await this.orgaMembers(repoIdent.owner),

--- a/src/github-api/model/DevFocus.ts
+++ b/src/github-api/model/DevFocus.ts
@@ -65,3 +65,9 @@ export interface RepoSpreadTotal {
   sprintSpread: { [key: string]: number };
   monthSpread: { [key: string]: number };
 }
+
+export interface SprintData {
+  begin: string;
+  end: string;
+  developers: string[];
+}


### PR DESCRIPTION
This PR includes the separating of the sprint spread computation with external sprint data.
I have created a dedicated interface `SprintData` as a suggestion for a data model for sprint data including `begin`, `end` and `developers` properties.

They can be passed into `devSpreadTotal()` in an array. Then, based on that data, the sprint spread is calculated with the help of single commit spread data.

Currently, I assume to receive unordered data from an organization. We can add a sorting function based on the *begin* timestamps, if the data model is suitable.