### PR TITLE
Feature/pull commits

### DIFF
--- a/src/github-api/github-api.service.ts
+++ b/src/github-api/github-api.service.ts
@@ -397,8 +397,9 @@ export class GithubApiService {
       );
       return;
     }
-    const repoId = await this.dbService.createRepo(repoIdent);
-    this.processCommits(repoIdent.owner, repoIdent.repo, repoId, 1);
+    this.logger.log(`Retrieving commits of repo ${repoIdent.owner}/${repoIdent.repo}`)
+    const repoId = await this.dbService.getRepoByName(repoIdent.owner, repoIdent.repo);
+    await this.processCommits(repoIdent.owner, repoIdent.repo, repoId, 1);
   }
 
   private async processCommits(
@@ -412,15 +413,14 @@ export class GithubApiService {
       repo: repo,
       per_page: 100,
       page: pageNumber,
-
     });
     for (const commit of commits) {
-      const commitDocument: Commit = {
-        url: commit.commit.url,
-        login: commit.commit.committer.email,
-        timestamp: commit.commit.committer.date,
-      };
-      await this.dbService.saveCommit(repoId, commitDocument);
+        const commitDocument: Commit = {
+          url: commit.commit.url,
+          login: commit.commit.author.email,
+          timestamp: commit.commit.author.date,
+        };
+        await this.dbService.saveCommit(repoId, commitDocument);
     }
 
     if (commits.length == 100) {


### PR DESCRIPTION
I updated the /commits endpoint to actually retrieve **all** commits of the given repository. The previous implementation forgot to handle the pagination present in the GitHub API.

Additionally, I the `committer` and `author` fields are only set if the changes were committed from an email linked to a GitHub account. Otherwise, they are set to `null`. For now, I changed the Commit documents to use the author's email as login name.

For further information on the difference between author and committer, see [here](https://ivan.bessarabov.com/blog/git-author-committer).