### PR TITLE
Issue Label Priorities for Dev Focus 

### DIFF
--- a/src/kpi/statistics/developerFocus/issueLabels.service.ts
+++ b/src/kpi/statistics/developerFocus/issueLabels.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { wAvgPerDev } from './model';
+import { RepositoryDocument } from '../../../repositories/model/schemas';
+import { getIssueLabelQuery } from './lib/issueLabelQueries';
+
+@Injectable()
+export class IssueLabels {
+  private readonly logger = new Logger(IssueLabels.name);
+
+  constructor(
+    @InjectModel('Repository')
+    private readonly repoModel: Model<RepositoryDocument>,
+  ) {}
+
+  /**
+   * Computes the weighted avg times (days, weeks, months)
+   * for completion for all label categorys of a repository
+   * @param repoId. It includes the first @param issueLimit
+   * issues and only considers devs who are in @param loginFilter.
+   */
+  async labelPrioritiesAvg(
+    repoId: string,
+    loginFilter?: string[],
+    issueLimit?: number,
+  ) {
+    const issueLabelQuery = getIssueLabelQuery(
+      this.repoModel,
+      repoId,
+      loginFilter,
+      issueLimit,
+    );
+
+    const dataForWeightedAvg = await issueLabelQuery.exec();
+
+    //console.log(dataForWeightedAvg);
+
+    const wAvg: wAvgPerDev = {};
+
+    computeWeightedAvg();
+
+    this.logger.log(wAvg);
+
+    function computeWeightedAvg() {
+      dataForWeightedAvg.forEach((label) => {
+        wAvg[label._id] = { daysAvg: 0, weeksAvg: 0, monthsAvg: 0 };
+        for (let i = 0; i < label.assignee.length; i++) {
+          wAvg[label._id].daysAvg +=
+            label.dayAvg[i] * (label.count[i] / label.total);
+          wAvg[label._id].weeksAvg +=
+            label.weekAvg[i] * (label.count[i] / label.total);
+          wAvg[label._id].monthsAvg +=
+            label.monthAvg[i] * (label.count[i] / label.total);
+        }
+      });
+    }
+
+    return wAvg;
+  }
+}

--- a/src/kpi/statistics/developerFocus/lib/issueLabelQueries.ts
+++ b/src/kpi/statistics/developerFocus/lib/issueLabelQueries.ts
@@ -1,0 +1,157 @@
+import { Aggregate, Model } from 'mongoose';
+import { avgDataPerLabel } from '../model';
+import { RepositoryDocument } from '../../../../repositories/model/schemas';
+
+const lookupIssuesWithEvents = {
+  from: 'issuewithevents',
+  localField: 'issuesWithEvents',
+  foreignField: '_id',
+  as: 'expandedIssuesWithEvents',
+};
+
+const lookupIssueEventTypes = {
+  from: 'issueeventtypes',
+  localField: 'expandedIssuesWithEvents.issueEventTypes',
+  foreignField: '_id',
+  as: 'expanadedissueEventTypes',
+};
+
+const lookupIssue = {
+  from: 'issues',
+  localField: 'expandedIssuesWithEvents.issue',
+  foreignField: '_id',
+  as: 'expandedIssue',
+};
+
+const lookupLabels = {
+  from: 'labels',
+  localField: 'expandedIssue.label',
+  foreignField: '_id',
+  as: 'expandedLabels',
+};
+
+const lookupAssignees = {
+  from: 'assignees',
+  localField: 'expandedIssue.assignees',
+  foreignField: '_id',
+  as: 'expandedAssignees',
+};
+
+/**
+ * Querys every issue in repo @param repoId
+ * (until @param issueLimit) and expands every issue
+ * for every dev (who is in @param loginFilter)
+ * and for every label labeled.
+ * Then, it extends that query to compute data for
+ * weighted avg directly on the database.
+ * @returns the final query
+ */
+export function getIssueLabelQuery(
+  repomodel: Model<RepositoryDocument>,
+  repoId: string,
+  loginFilter?: string[],
+  issueLimit: number = 100,
+): Aggregate<avgDataPerLabel[]> {
+  const query: Aggregate<avgDataPerLabel[]> = repomodel
+    .aggregate()
+    .match({ repo: repoId })
+    .project({ issuesWithEvents: 1 })
+    .unwind('$issuesWithEvents')
+    .lookup(lookupIssuesWithEvents)
+    .unwind('$expandedIssuesWithEvents')
+    .lookup(lookupIssueEventTypes)
+    .unwind('$expanadedissueEventTypes')
+    .match({
+      'expanadedissueEventTypes.event': { $in: ['assigned', 'labeled'] },
+    })
+    .lookup(lookupIssue)
+    .unwind('$expandedIssue')
+    .project({ expandedIssue: 1 })
+    .lookup(lookupAssignees)
+    .unwind('$expandedAssignees')
+    .lookup(lookupLabels)
+    .unwind('expandedLabels')
+    .group({
+      _id: '$expandedIssue',
+      assignees: { $addToSet: '$expandedAssignees.login' },
+      labels: { $addToSet: '$expandedLabels.name' },
+    })
+    .limit(issueLimit) // limit amount of issues
+    .unwind('assignees');
+
+  if (loginFilter) {
+    query.match({ assignees: { $in: loginFilter } });
+  }
+
+  const issues = query.unwind('labels').project({
+    id: '$_id._id',
+    name: '$_id.title',
+    assignee: '$assignees',
+    label: '$labels',
+    creation: '$_id.created_at',
+    closing: { $ifNull: ['$_id.closed_at', new Date()] },
+    _id: 0,
+  });
+
+  return extendQueryToAvgData(issues);
+}
+
+/**
+ * Extends @param query to compute all data
+ * necessary to calculate weigthed avg
+ * and @returns the query.
+ */
+function extendQueryToAvgData(query: Aggregate<avgDataPerLabel[]>) {
+  // get amount of days, weeks, months from creation to closing
+  query.project({
+    id: '$id',
+    name: '$name',
+    assignee: '$assignee',
+    label: '$label',
+    days: {
+      $dateDiff: {
+        startDate: { $toDate: '$creation' },
+        endDate: { $toDate: '$closing' },
+        unit: 'day',
+      },
+    },
+    weeks: {
+      $dateDiff: {
+        startDate: { $toDate: '$creation' },
+        endDate: { $toDate: '$closing' },
+        unit: 'week',
+      },
+    },
+    months: {
+      $dateDiff: {
+        startDate: { $toDate: '$creation' },
+        endDate: { $toDate: '$closing' },
+        unit: 'month',
+      },
+    },
+  });
+
+  // avg per dev per label
+  const avg = query.group({
+    _id: { assignee: '$assignee', label: '$label' },
+    count: { $sum: 1 },
+    dayAvg: { $avg: '$days' },
+    weekAvg: { $avg: '$weeks' },
+    monthAvg: { $avg: '$months' },
+  });
+
+  // data to compute weigthed avg
+  const total = avg.group({
+    _id: '$_id.label',
+    total: { $sum: '$count' },
+    count: { $push: '$count' },
+    assignee: { $push: '$_id.assignee' },
+    dayAvg: {
+      $push: '$dayAvg',
+    },
+    weekAvg: { $push: '$weekAvg' },
+    monthAvg: { $push: '$monthAvg' },
+  });
+
+  return total;
+}

--- a/src/kpi/statistics/developerFocus/model/DevFocus.ts
+++ b/src/kpi/statistics/developerFocus/model/DevFocus.ts
@@ -74,3 +74,17 @@ export interface SprintData {
   end: string;
   developers: string[];
 }
+
+export interface avgDataPerLabel {
+  _id: string;
+  total: number;
+  count: number[];
+  assignee: string[];
+  dayAvg: number[];
+  weekAvg: number[];
+  monthAvg: number[];
+}
+
+export interface wAvgPerDev {
+  [key: string]: { daysAvg: number; weeksAvg: number; monthsAvg: number };
+}


### PR DESCRIPTION
This PR integrates the issue label priority computation to the developer focus part. I tried to use the aggregation pipeline as long as it works. We get the weighted avg completion time for every kind of label for a repository in days, weeks and months.